### PR TITLE
Fixed node hang, punched up error path, and lowered default keepAlive time 

### DIFF
--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -31,13 +31,9 @@ var MongoDB = exports.MongoDB = function (options) {
   this.silent     = options.silent     || false;
   this.username   = options.username   || null;
   this.password   = options.password   || null;
-  this.keepAlive  = options.keepAlive  || 10000;
+  this.keepAlive  = options.keepAlive  || 100;
   this.state      = 'unopened';
   this.pending    = [];
-  
-  this.client = new mongodb.Db(this.db, new mongodb.Server(this.host, this.port, {}), { 
-    native_parser : false
-  });
 };
 
 //
@@ -50,6 +46,10 @@ util.inherits(MongoDB, winston.Transport);
 // is available and thus backwards compatible.
 //
 winston.transports.MongoDB = MongoDB;
+
+MongoDB.prototype.makeClient = function(){
+    return( new mongodb.Db(this.db, new mongodb.Server(this.host, this.port, {}), { native_parser : false }) );
+};
 
 //
 // ### function log (level, msg, [meta], callback)
@@ -65,15 +65,18 @@ MongoDB.prototype.log = function (level, msg, meta, callback) {
   if (this.silent) {
     return callback(null, true);
   }
-    
+
   this.open(function (err) {
+    
     if (err) {
       self.emit('error', err);
+      return callback(err, null);
     }
-    
+        
     self._db.collection(self.collection, function (err, col) {
       if (err) {
         self.emit('error', err);
+        return callback(err, null);
       }
 
       var entry = {
@@ -86,14 +89,14 @@ MongoDB.prototype.log = function (level, msg, meta, callback) {
       col.save(entry, { safe: self.safe }, function (err, doc) {
         if (err) {
           self.emit('error', err);
+          return callback(err, null);
+        }else{
+          self.emit('logged');
+          return callback(null, true);
         }
-
-        self.emit('logged');
       });
     });
   });
-  
-  callback(null, true);
 };
 
 //
@@ -104,7 +107,7 @@ MongoDB.prototype.log = function (level, msg, meta, callback) {
 //
 MongoDB.prototype.open = function (callback) {
   var self = this;
-  
+
   if (this.state === 'opening' || this.state === 'unopened') {
     //
     // While opening our MongoDB connection, append any callback
@@ -146,7 +149,8 @@ MongoDB.prototype.open = function (callback) {
   }
     
   this.state = 'opening';
-  this.client.open(function (err, db) {
+  
+  this.makeClient().open(function (err, db) {
     if (err) {
       return onError(err);
     }


### PR DESCRIPTION
There was still something on the work queue in node for the mongo driver so node never exited.  Fixed node hang, punched up error path, and lowered default keepAlive time so you don't hang small scripts for 10 seconds, fixed callback structure of the log method.
