### PR TITLE
change default collection name using plural ('log' to 'logs')

### DIFF
--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -29,7 +29,7 @@ var MongoDB = exports.MongoDB = function (options) {
   this.db           = options.db;
   this.host         = options.host || 'localhost';
   this.port         = options.port || mongodb.Connection.DEFAULT_PORT;
-  this.collection   = options.collection || 'log';
+  this.collection   = options.collection || 'logs';
   this.safe         = options.safe || true;
   this.level        = options.level || 'info';
   this.silent       = options.silent || false;


### PR DESCRIPTION
Not to confuse people who use mongoose to query the log. Mongoose using plural collection name.
