### PR TITLE
[api] Added new [query & stream] option:

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ The MongoDB transport takes the following options. 'db' is required:
 
 *Metadata:* Logged as a native JSON object.
 
+## Querying Logs
+
+Besides supporting the main options from winston, this transport supports the following extra options:
+
+* __includeIds:__ Whether the returned logs should include the `_id` attribute settled by mongodb, defaults to `false`.
+
 ## Installation
 
 ### Installing npm (node package manager)

--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -210,9 +210,11 @@ MongoDB.prototype.query = function (options, callback) {
     if (err) return callback(err);
     col.find(query, opt).toArray(function (err, docs) {
       if (err) return callback(err);
-      docs.forEach(function (log) {
-        delete log._id;
-      });
+      if (!options.includeIds) {
+        docs.forEach(function (log) {
+          delete log._id;
+        });
+      }
       if (callback) callback(null, docs);
     });
   });
@@ -283,7 +285,9 @@ MongoDB.prototype.stream = function (options, stream) {
     };
 
     tail.on('data', function (doc) {
-      delete doc._id;
+      if (!options.includeIds) {
+        delete doc._id;
+      }
       stream.emit('log', doc);
     });
 
@@ -359,7 +363,9 @@ MongoDB.prototype.streamPoll = function (options, stream) {
 
         if (start == null) {
           docs.forEach(function (doc) {
-            delete doc._id;
+            if (!options.includeIds) {
+              delete doc._id;
+            }
             stream.emit('log', doc);
           });
         } else {


### PR DESCRIPTION
```
- To let users specify if they want the `_id`s included.
- The corresponding documentation.
```

I know this PR can generate a lot of hate but here it goes.

This PR is for add an option to let users receive the mongdb `_ids` related to the logs.

I found a [commit](ee96d20b677ef27b990b3366522f377dcf34771a) were this feature was explicitely removed but it is really useful (I need to uniquelly identify logs!), so please, can you consider adding this?

I tried to find a workaround to this by treating `timestamp`s like ids, but they clashed and got repeated due simultaneosly event logging making this path inviable.

I left the default behaviour intact, so if the options is not specified it will remove all ids.

I also added this feature to `query` and `stream` for uniformity, but I needed it only in `query`.

Also added the docs to this options.

Hope you like it and got merged.
