### PR TITLE
Added MIT license type to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,6 @@
   },
   "main": "./lib/winston-mongodb",
   "scripts": { "test": "vows test/*-test.js --spec" },
-  "engines": { "node": ">= 0.4.0" }
+  "engines": { "node": ">= 0.4.0" },
+  "license": "MIT"
 }


### PR DESCRIPTION
This project appears to not have a license type, I recommend using MIT (another alternative would be BSD). In addition, tools like license-checker need a valid "license" property.
