### PR TITLE
Fix for MongoDB transport not handling exceptions (issue #24).

### DIFF
--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -18,6 +18,7 @@ var Stream = require('stream').Stream;
 // Constructor for the MongoDB transport object.
 //
 var MongoDB = exports.MongoDB = function (options) {
+  winston.Transport.call(this, options);
   options = options || {};
 
   if (!options.db) {


### PR DESCRIPTION
Fix for handleExceptions: true not working (#24).

Added missing line Transport.call(this, options) to the MongoDB transport constructor (see other transports examples: https://github.com/flatiron/winston/blob/master/lib/winston/transports/console.js). 
