### PR TITLE
Added 'name' as a transport option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ which stores os.hostname() value.
 `{host: 'string', port: 'number'}`)
 * __dbUri:__ Alternative way of specifying database connection data. Supported
 specifying database, host, port, username, password and replica sets.
+* __name:__ Transport instance identifier. Useful if you need to create multiple MongoDB transports.
 
 *Notice:* __db__ is required. You should specify it directly or in __dbUri__.
 

--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -44,7 +44,7 @@ var MongoDB = exports.MongoDB = function (options) {
 
   var self = this;
 
-  this.name         = 'mongodb';
+  this.name         = options.name || 'mongodb';
   this.db           = options.db;
   this.host         = (options.host || 'localhost');
   this.port         = (options.port || mongodb.Connection.DEFAULT_PORT);


### PR DESCRIPTION
#### What's this PR do?

This would allow for winston to log to different databases.

example:

```
var logger = new (winston.Logger) ({
  transports: [
    new winston.transports.MongoDB({name: 'mongodb-info', dbUri: uri_1}),
    new winston.transports.MongoDB({name: 'mongodb-error', dbUri: uri_2})
  ]
});
```
#### What are the relevant tickets?
#40
