### PR TITLE
Closing transport using Logger.close

### DIFF
--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -194,6 +194,24 @@ util.inherits(MongoDB, winston.Transport);
  */
 winston.transports.MongoDB = MongoDB;
 
+/**
+ * Closes MongoDB connection so using process would not hang up.
+ * Used by winston.close on transports.
+ */
+MongoDB.prototype.close = function () {
+  var self = this;
+  
+  if (this.logDb) {
+    this.logDb.close(function (error) {
+      if(error) {
+        console.error('Winston MongoDB transport encountered on error during closing.', error);
+      } else {
+        console.info('Winston MongoDB transport was closed.');
+        self.logDb = null;
+      }
+    });
+  }
+};
 
 /**
  * Core logging method exposed to Winston. Metadata is optional.

--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -196,7 +196,7 @@ winston.transports.MongoDB = MongoDB;
 
 /**
  * Closes MongoDB connection so using process would not hang up.
- * Used by winston.close on transports.
+ * Used by winston Logger.close on transports.
  */
 MongoDB.prototype.close = function () {
   var self = this;
@@ -206,7 +206,6 @@ MongoDB.prototype.close = function () {
       if(error) {
         console.error('Winston MongoDB transport encountered on error during closing.', error);
       } else {
-        console.info('Winston MongoDB transport was closed.');
         self.logDb = null;
       }
     });


### PR DESCRIPTION
There is a possibility to close all logger transports using Logger.close method. That is useful for manual releasing of transports' resources, like MongoDB connection in this case. Original implementation did not provide close method usable by winston's Logger => we encountered process hanging up and not finishing due to opened MongoDB connection after finishing its execution.