### PR TITLE
Decolorize log messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ and a File is overkill.
 ## Usage
 ``` js
   var winston = require('winston');
-  
+
   /**
    * Requiring `winston-mongodb` will expose
    * `winston.transports.MongoDB`
    */
   require('winston-mongodb').MongoDB;
-  
+
   winston.add(winston.transports.MongoDB, options);
 ```
 
@@ -55,6 +55,8 @@ new log collection as capped, defaults to false.
 * __cappedMax:__ Size of logs capped collection in number of documents.
 * __tryReconnect:__ Will try to reconnect to the database in case of fail during
 initialization. Works only if __db__ is a string. Defaults to false.
+* __decolorize__ Will remove color attributes from the log entry message,
+defaults to false.
 
 *Metadata:* Logged as a native JSON object in 'meta' property.
 

--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -49,6 +49,8 @@ var helpers = require('./helpers');
  * @param {boolean=false} options.tryReconnect Will try to reconnect to the
  * database in case of fail during initialization. Works only if `db` is
  * a string.
+ * @param {boolean=false} options.decolorize Will remove color attributes from
+ * the log entry message.
  */
 var MongoDB = exports.MongoDB = function(options) {
   winston.Transport.call(this, options);
@@ -82,6 +84,7 @@ var MongoDB = exports.MongoDB = function(options) {
   this.capped = options.capped;
   this.cappedSize = (options.cappedSize || 10000000);
   this.cappedMax = options.cappedMax;
+  this.decolorize = options.decolorize;
 
   if (this.storeHost) {
     this.hostname = os.hostname();
@@ -254,7 +257,7 @@ MongoDB.prototype.log = function(level, msg, opt_meta, callback) {
       }
 
       var entry = {};
-      entry.message = msg;
+      entry.message = self.decolorize ? msg.replace(/\u001b\[[0-9]{1,2}m/g, '') : msg;
       entry.timestamp = new Date();
       entry.level = level;
       entry.meta = helpers.prepareMetaData(opt_meta);


### PR DESCRIPTION
Removes color attributes from log messages before storing them in
MongoDB. (Issue #62)
