### PR TITLE
Add meteor compatibility

### DIFF
--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -268,7 +268,7 @@ MongoDB.prototype.log = function(level, msg, opt_meta, callback) {
         entry.label = self.label;
       }
 
-      col.insertOne(entry, function(err) {
+      col.insert(entry, function(err) {
         if (err) {
           onError(err);
           return;


### PR DESCRIPTION
Meteor does not yet support use of mongodb's insertOne function, and instead [uses insert](http://docs.meteor.com/api/collections.html#Mongo-Collection-insert). This issue would be fixed by reverting to an older version of winston-mongodb, but the older version causes separate issues with meteor.
Since the only difference between the two functions appears to be the object they return, and winston-mongodb does not appear to do anything with this object, switching from insertOne to insert should not cause any issues. The meteor team [does not seem to plan on changing their API any time soon] (https://forums.meteor.com/t/updating-the-mongo-collection-api/17002), so I think it would be best to use insert for the time being in order to make winston-mongodb compatible with meteor. 
I can provide more detail on the exact issue I was having if needed.