### PR TITLE
Use hasOwnProperty from Object prototype (Node v6.x)

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -38,7 +38,7 @@ exports.prepareMetaData = function(meta) {
  */
 function cleanFieldNames(object) {
   for (var field in object) {
-    if (!object.hasOwnProperty(field)) {
+    if (!Object.prototype.hasOwnProperty.call(object, field)) {
       continue;
     }
     var value = object[field];


### PR DESCRIPTION
Was running into an issue with `hasOwnProperty`:

```
TypeError: object.hasOwnProperty is not a function
    at cleanFieldNames (/.../node_modules/winston-mongodb/lib/helpers.js:41:17)
    at cleanFieldNames (/.../node_modules/winston-mongodb/lib/helpers.js:56:7)
    at cleanFieldNames (/.../node_modules/winston-mongodb/lib/helpers.js:56:7)
    at Object.exports.prepareMetaData (/.../node_modules/winston-mongodb/lib/helpers.js:18:5)
    at /.../node_modules/winston-mongodb/lib/winston-mongodb.js:263:28
    at Db.collection (/.../node_modules/mongodb/lib/db.js:449:20)
    at /.../node_modules/winston-mongodb/lib/winston-mongodb.js:253:16
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```

Seems to be caused by a change in Node v6:
- https://github.com/nodejs/node/wiki/Breaking-changes-between-v5-and-v6#querystring
- https://github.com/nodejs/node/pull/6055
- https://github.com/nodejs/node/pull/6289

Updated to use `hasOwnProperty` from the Object prototype object instead.