### PR TITLE
cleanFieldNames replaces dots and dollar characters globally

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -44,12 +44,12 @@ function cleanFieldNames(object) {
     var value = object[field];
     if (field.indexOf('.') !== 0) {
       delete object[field];
-      field = field.replace('.', '[dot]');
+      field = field.replace(/\./g, '[dot]');
       object[field] = value;
     }
     if (field.indexOf('$') === 0) {
       delete object[field];
-      field = field.replace('$', '[$]');
+      field = field.replace(/\$/g, '[$]');
       object[field] = value;
     }
     if (typeof value === 'object') {


### PR DESCRIPTION
when logging an object with key that contains multiple dots - mongo will throw and error because current code only substitutes the first dot or $.

```json
{
   "a.b.c": "abc" //will be translated to "a[dot]b.c" --> will cause mongo error
}
```

replace now gets a regex to replace all dot and $ instances.