### PR TITLE
Fixed bad logical operator test for setting expireAfterSeconds option…

### DIFF
--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -80,7 +80,7 @@ let MongoDB = exports.MongoDB = function(options) {
   this.cappedSize = (options.cappedSize || 10000000);
   this.cappedMax = options.cappedMax;
   this.decolorize = options.decolorize;
-  this.expireAfterSeconds = this.capped && options.expireAfterSeconds;
+  this.expireAfterSeconds = !this.capped && options.expireAfterSeconds;
   if (this.storeHost) {
     this.hostname = os.hostname();
   }


### PR DESCRIPTION
I was trying to implement the new expireAfterSeconds option to winston-mongodb and the TTL index was not created on any of my logging collections, even if I dropped the collections and let winston-mongodb recreate them. I believe that the problem is that despite the docs saying that the expireAfterSeconds option only is in play if the capped option is NOT set, the code for setting the expireAfterSeconds option actually has a logical operator test that checks if 'this.capped && options.expireAfterSeconds'. With that test, if capped is set as false or false via default, then the expireAfterSeconds option is actually not evaluated.

I tested simply changing this.capped to !this.capped and the result was successful creation of my logging collections with the TTL index.

Note I am testing on 1.6.5 since we are not ready to move to node 6.x but the change is a one liner and so should apply just the same on the 2.x version.