### PR TITLE
dropIndex removed

### DIFF
--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -112,13 +112,7 @@ let MongoDB = exports.MongoDB = function(options) {
       if (self.expireAfterSeconds) {
         indexOpts.expireAfterSeconds = self.expireAfterSeconds;
       }
-      // TODO: drop index only if params changed
-      return col.dropIndex(ttlIndexName).catch(err=>{
-        if (err.code !== 27) {
-          throw err;
-        }
-      }).then(()=>col.createIndex({timestamp: -1}, indexOpts)
-      ).then(()=>db);
+      return col.createIndex({timestamp: -1}, indexOpts).then(()=>db);
     });
   }
   function authorizeDb(db) {


### PR DESCRIPTION
In createCollection method, remove dropIndex method.
createCollection is called only the first time when collection is not exist, so index is already not found.