### PR TITLE
Flat options structure in MongoClient.connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ false.
 * __db:__ MongoDB connection uri, pre-connected db object or promise object
 which will be resolved with pre-connected db object.
 * __options:__ MongoDB connection parameters (optional, defaults to
-`{db: {native_parser: true}, server: {poolSize: 2, socketOptions: {autoReconnect: true}}}`).
+`{poolSize: 2, autoReconnect: true}`).
 * __collection__: The name of the collection you want to store log messages in,
 defaults to 'log'.
 * __storeHost:__ Boolean indicating if you want to store machine hostname in

--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -26,8 +26,7 @@ const helpers = require('./helpers');
  * @param {string|Object} options.db MongoDB connection uri or preconnected db
  * object.
  * @param {Object} options.options MongoDB connection parameters
- * (optional, defaults to `{db: {native_parser: true},
- * server: {poolSize: 2, socketOptions: {autoReconnect: true}}}`).
+ * (optional, defaults to `{poolSize: 2, autoReconnect: true}`).
  * @param {string=logs} options.collection The name of the collection you want
  * to store log messages in.
  * @param {boolean=false} options.storeHost Boolean indicating if you want to
@@ -65,8 +64,8 @@ let MongoDB = exports.MongoDB = function(options) {
   this.options = options.options;
   if (!this.options) {
     this.options = {
-      db: {native_parser: true},
-      server: {poolSize: 2, socketOptions: {autoReconnect: true}}
+      poolSize: 2,
+      autoReconnect: true
     };
   }
   this.collection = (options.collection || 'log');

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "keywords": ["logging", "sysadmin", "tools", "winston", "mongodb", "log", "logger"],
   "dependencies": {
-    "mongodb": "^2.0.46"
+    "mongodb": "^2.2.19"
   },
   "devDependencies": {
     "winston": ">=1.1.1 <3.0.0",


### PR DESCRIPTION
MongoClient.connect now using flat options structure - http://mongodb.github.io/node-mongodb-native/2.2/api/MongoClient.html

If 'old' style options used, mongodb client logs deprecated warnings to console.