### PR TITLE
Allow to customize the mongodb document and collection

### DIFF
--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -52,6 +52,8 @@ const helpers = require('./helpers');
  * @param {boolean=false} options.decolorize Will remove color attributes from
  * the log entry message.
  * @param {number} options.expireAfterSeconds Seconds before the entry is removed. Do not use if capped is set.
+ * @param {function} options.trasformDocument A function that takes the default log document and trasform it to another document. Optional.
+ * @param {boolean=false} options.doNotCreateCollection Will disable the collection creation at startup.
  */
 let MongoDB = exports.MongoDB = function(options) {
   winston.Transport.call(this, options);
@@ -83,6 +85,9 @@ let MongoDB = exports.MongoDB = function(options) {
   if (this.storeHost) {
     this.hostname = os.hostname();
   }
+  this.trasformDocument = options.trasformDocument || function(d){return d;};
+  this.doNotCreateCollection = options.doNotCreateCollection;
+
   this._opQueue = [];
   let self = this;
 
@@ -101,6 +106,9 @@ let MongoDB = exports.MongoDB = function(options) {
     delete self._opQueue;
   }
   function createCollection(db) {
+    if (this.doNotCreateCollection) {
+      return Promise.resolve(db);
+    }
     let opts = self.capped ?
       {capped: true, size: self.cappedSize, max: self.cappedMax} : {};
     return db.createCollection(self.collection, opts).then(col=>{
@@ -214,6 +222,7 @@ MongoDB.prototype.log = function(level, msg, opt_meta, cb) {
     if (this.label) {
       entry.label = this.label;
     }
+    entry = this.trasformDocument(entry);
     this.logDb.collection(this.collection).insertOne(entry).then(()=>{
       this.emit('logged');
       cb(null, true);

--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -106,7 +106,7 @@ let MongoDB = exports.MongoDB = function(options) {
     delete self._opQueue;
   }
   function createCollection(db) {
-    if (this.doNotCreateCollection) {
+    if (self.doNotCreateCollection) {
       return Promise.resolve(db);
     }
     let opts = self.capped ?


### PR DESCRIPTION
I need my logs to be compliant with an existing application that use a different document convention (different field names). For this reason I have added an option that can be used to customize the written document (the `entry` object passed to the `insertOne` method). I have also added an option to disable the collection creation because I use different indexes.

You can use this features like this:

```
winston.configure({
	transports: [
		new WinstonMongoDB({
			db: "...",
			collection: "logs",
			doNotCreateCollection: true,
			trasformDocument: (d: any) => {
				if (d.level === "error") {
					d.exception = d.message;
				}
				return d;
			}
		})
	]
});
```

What do you think?