### PR TITLE
Preserve Arrays during circular reference removal

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -59,7 +59,12 @@ function cleanFieldNames(object) {
 function makeObjectNonCircular(node, opt_parents) {
   opt_parents = opt_parents || [];
   opt_parents.push(node);
-  let copy = {};
+  let copy;
+  if (Array.isArray(node)) {
+    copy = [];
+  } else {
+    copy = {};
+  }
   for (let key in node) {
     if (!Object.prototype.hasOwnProperty.call(node, key)) {
       continue;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -59,12 +59,7 @@ function cleanFieldNames(object) {
 function makeObjectNonCircular(node, opt_parents) {
   opt_parents = opt_parents || [];
   opt_parents.push(node);
-  let copy;
-  if (Array.isArray(node)) {
-    copy = [];
-  } else {
-    copy = {};
-  }
+  let copy = Array.isArray(node) ? [] : {};
   for (let key in node) {
     if (!Object.prototype.hasOwnProperty.call(node, key)) {
       continue;


### PR DESCRIPTION
Fixes winstonjs/winston-mongodb#98