### PR TITLE
Fix documentation relating to db option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ The MongoDB transport takes the following options. 'db' is required:
 'info'.
 * __silent:__ Boolean flag indicating whether to suppress output, defaults to
 false.
-* __db:__ MongoDB connection uri, pre-connected db object or promise object
-which will be resolved with pre-connected db object.
+* __db:__ MongoDB connection uri, pre-connected `MongoClient` object or promise
+which resolves to a pre-connected `MongoClient` object.
 * __options:__ MongoDB connection parameters (optional, defaults to
 `{poolSize: 2, autoReconnect: true}`).
 * __collection__: The name of the collection you want to store log messages in,


### PR DESCRIPTION
Currently the documention is not clear as to what type of object the `db` option is expecting. In version `3.0.0` a preconnected `Db` object was accepted, but since `4.0.0`, a `MongoClient` is accepted instead.