### PR TITLE
Removing trailing comma in function call

### DIFF
--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -96,7 +96,7 @@ let MongoDB = exports.MongoDB = function(options) {
   function createCollection(db) {
     let opts = Object.assign(
       {strict: false},
-      self.capped ? {capped: true, size: self.cappedSize, max: self.cappedMax} : {},
+      self.capped ? {capped: true, size: self.cappedSize, max: self.cappedMax} : {}
     );
     return db.createCollection(self.collection, opts).then(col=>{
       const ttlIndexName = 'timestamp_1';


### PR DESCRIPTION
I'm running NodeJS v6.14.3 and have just updated to winston v3.0.0 and winston-mongodb 4.0.3.

When I try to initialize the mongodb transport I get the following error and then the process exits:

```
node_modules/winston-mongodb/lib/winston-mongodb.js:100
SyntaxError: Unexpected token )
```

Trailing commas in function calls are not supported in NodeJS < v8 and crashes the process upon transport initialization.

Removing comma.