### PR TITLE
Add { useNewUrlParser: true } by default

### DIFF
--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -60,7 +60,8 @@ let MongoDB = exports.MongoDB = function(options) {
   if (!this.options) {
     this.options = {
       poolSize: 2,
-      autoReconnect: true
+      autoReconnect: true,
+      useNewUrlParser: true,
     };
   }
   this.collection = (options.collection || 'log');


### PR DESCRIPTION
In order to fix the deprecation warning message from Mongo : 
```
(node:24640) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.
```