### PR TITLE
Allow configuring of metadata key

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ new log collection as capped, defaults to false.
 initialization. Works only if __db__ is a string. Defaults to false.
 * __decolorize:__ Will remove color attributes from the log entry message,
 defaults to false.
+* __metaKey:__ Configure which key is used to store metadata in the logged info object.
+Defaults to `'metadata'` to remain compatible with the [metadata format](https://github.com/winstonjs/logform/blob/master/examples/metadata.js)
 * __expireAfterSeconds:__ Seconds before the entry is removed. Works only if __capped__ is not set.
 
 *Metadata:* Logged as a native JSON object in 'meta' property.

--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -73,6 +73,7 @@ let MongoDB = exports.MongoDB = function(options) {
   this.cappedMax = options.cappedMax;
   this.decolorize = options.decolorize;
   this.expireAfterSeconds = !this.capped && options.expireAfterSeconds;
+  this.metaKey = options.metaKey || 'metadata';
   if (this.storeHost) {
     this.hostname = os.hostname();
   }
@@ -193,7 +194,7 @@ MongoDB.prototype.log = function(info, cb) {
     let entry = {timestamp: new Date(), level: info.level};
     let message = util.format(info.message, ...(info.splat || []));
     entry.message = this.decolorize ? message.replace(/\u001b\[[0-9]{1,2}m/g, '') : message;
-    entry.meta = helpers.prepareMetaData(info.meta);
+    entry.meta = helpers.prepareMetaData(info[this.metaKey]);
     if (this.storeHost) {
       entry.hostname = this.hostname;
     }


### PR DESCRIPTION
In `wintson@3` there is no more `meta` key by default inside the `info` object in `winston@3`. It could be added with `formatters`, but the `metadata` formatter now stores it as `metadata` instead of `meta` by default.