### PR TITLE
Make it easier to use typescript typing

### DIFF
--- a/lib/winston-mongodb.d.ts
+++ b/lib/winston-mongodb.d.ts
@@ -19,7 +19,7 @@ declare module 'winston' {
 
 declare module 'winston-mongodb' {
     export interface MongoDBTransportInstance extends transports.StreamTransportInstance {
-        new (options: MongoDBConnectionOptions) : MongoDBTransportInstance;
+        new (options?: MongoDBConnectionOptions) : MongoDBTransportInstance;
         query: (callback: Function, options?: any) => Promise<any>;
     }
 

--- a/lib/winston-mongodb.d.ts
+++ b/lib/winston-mongodb.d.ts
@@ -147,4 +147,6 @@ declare module 'winston-mongodb' {
         */
        expireAfterSeconds?: number;
     }
+    
+    const MongoDB: MongoDBTransportInstance;
 }


### PR DESCRIPTION
This contains two changes:
1. Make the constructor inline with transports.StreamTransportInstance such that options can be null/undefined. This fixes type-hinting on the constructor.
2. Make it easier to import/define the MongoDB transport in a downstream project.

As pointed out in https://github.com/winstonjs/winston-mongodb/issues/152#issuecomment-473873531, it's pretty convoluted to use the typings.

Adding this change allows one to more simply use:
```typescript
import { MongoDB } from 'winston-mongodb';

let a = new MongoDB({
  "db": "test"
});
```

The `winston.transports.MongoDB` typing still doesn't work, but I'm not sure how to fix that. This at least follows a similar approach though as the winston-daily-rotate-file in exporting a concrete usage of the TransportInstance to use directly.


A larger and probably more correct edit would be to edit the whole typing file to only export the MongoDB object, which is what winston-mongodb.js does, but I don't know why the interfaces are being exported, so I didn't make any changes there.