### PR TITLE
Fix createCollection error in mongodb@3.6

### DIFF
--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -102,28 +102,55 @@ let MongoDB = exports.MongoDB = function(options) {
       self[operation.method].apply(self, operation.args));
     delete self._opQueue;
   }
+  function getCollectionNames(db) {
+    if (typeof db.collections === 'function') {
+      return db.collections().then(collections=>{
+        return collections.map(col=>{
+          return col.s.namespace.collection;
+        });
+      })
+    } else {
+      // DEV: Can be removed when removing preconnected object support
+      return new Promise(resolve=>{
+        const collections = Object.keys(db.collections)
+        return resolve(collections)
+      })
+    }
+  }
+  function checkExistingCollection(db) {
+    return getCollectionNames(db).then(names=>{
+      return !!names.find(name=>{
+        return name === self.collection
+      });
+    });
+  }
   function createCollection(db) {
-    let opts = Object.assign(
-      {strict: false},
-      self.capped ? {capped: true, size: self.cappedSize, max: self.cappedMax} : {}
-    );
-    return db.createCollection(self.collection, opts).then(col=>{
-      const ttlIndexName = 'timestamp_1';
-      let indexOpts = {name: ttlIndexName, background: true};
-      if (self.expireAfterSeconds) {
-        indexOpts.expireAfterSeconds = self.expireAfterSeconds;
+    return checkExistingCollection(db).then(exists=>{
+      if (exists) {
+        return;
       }
-      return col.indexInformation({full: true}).then(info=>{
-        info = info.filter(i=>i.name === ttlIndexName);
-        if (info.length === 0) { // if its a new index then create it
-          return col.createIndex({timestamp: -1}, indexOpts);
-        } else { // if index existed with the same name check if expireAfterSeconds param has changed
-          if (info[0].expireAfterSeconds !== undefined &&
-              info[0].expireAfterSeconds !== self.expireAfterSeconds) {
-            return col.dropIndex(ttlIndexName)
-            .then(()=>col.createIndex({timestamp: -1}, indexOpts));
-          }
+      let opts = Object.assign(
+        {strict: false},
+        self.capped ? {capped: true, size: self.cappedSize, max: self.cappedMax} : {}
+      );
+      return db.createCollection(self.collection, opts).then(col=>{
+        const ttlIndexName = 'timestamp_1';
+        let indexOpts = {name: ttlIndexName, background: true};
+        if (self.expireAfterSeconds) {
+          indexOpts.expireAfterSeconds = self.expireAfterSeconds;
         }
+        return col.indexInformation({full: true}).then(info=>{
+          info = info.filter(i=>i.name === ttlIndexName);
+          if (info.length === 0) { // if its a new index then create it
+            return col.createIndex({timestamp: -1}, indexOpts);
+          } else { // if index existed with the same name check if expireAfterSeconds param has changed
+            if (info[0].expireAfterSeconds !== undefined &&
+                info[0].expireAfterSeconds !== self.expireAfterSeconds) {
+              return col.dropIndex(ttlIndexName)
+              .then(()=>col.createIndex({timestamp: -1}, indexOpts));
+            }
+          }
+        });
       });
     }).then(()=>db);
   }


### PR DESCRIPTION
`mongodb@3.6` introduced a breaking change: `Changes in behavior of Db.prototype.createCollection` (see [PR](https://github.com/mongodb/node-mongodb-native/pull/2278)). If a collection already exists, `createCollection` will through an error.

An alternative to this would be https://github.com/winstonjs/winston-mongodb/pull/121, however, the error message comparison would have to be updated.