### PR TITLE
FIX: TS Types MongoDBConnectionOptions

### DIFF
--- a/lib/winston-mongodb.d.ts
+++ b/lib/winston-mongodb.d.ts
@@ -28,7 +28,7 @@ declare module 'winston-mongodb' {
      * @export
      * @interface MongoDBConnectionOptions
      */
-    export interface MongoDBConnectionOptions {
+    export interface MongoDBConnectionOptions extends transports.StreamTransportOptions {
        /**
         * Level of messages that this transport should log, defaults to 'info'.
         *

--- a/package-lock.json
+++ b/package-lock.json
@@ -277,7 +277,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -1026,8 +1025,7 @@
         "bson": "^1.1.4",
         "denque": "^1.4.1",
         "require_optional": "^1.0.1",
-        "safe-buffer": "^5.1.2",
-        "saslprep": "^1.0.0"
+        "safe-buffer": "^5.1.2"
       },
       "engines": {
         "node": ">=4"


### PR DESCRIPTION
MongoDBConnectionOptions needs to extend the interface StreamTransportOptions so it can use the common transporter options such as 'format'