### PR TITLE
adding option to set the DB name

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The MongoDB transport takes the following options. 'db' is required:
 false.
 * __db:__ MongoDB connection uri, pre-connected `MongoClient` object or promise
 which resolves to a pre-connected `MongoClient` object.
+* __dbName:__ The database name to connect to, defaults to DB name based on 
+connection URI if not provided, ignored if using a pre-connected mongoose connection.
 * __options:__ MongoDB connection parameters (optional, defaults to
 `{poolSize: 2, autoReconnect: true, useNewUrlParser: true}`).
 * __collection__: The name of the collection you want to store log messages in,

--- a/lib/winston-mongodb.d.ts
+++ b/lib/winston-mongodb.d.ts
@@ -57,7 +57,14 @@ declare module 'winston-mongodb' {
         * @memberof MongoDBConnectionOptions
         */
        options?: any;
-       /**
+      /**
+       * The database name to connect to, defaults to DB name based on connection URI if not provided, ignored if using a pre-connected mongoose connection.
+       *
+       * @type {string}
+       * @memberof MongoDBConnectionOptions
+       */
+      dbName?: string;
+      /**
         * The name of the collection you want to store log messages in, defaults to 'log'.
         *
         * @type {string}

--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -26,6 +26,8 @@ const helpers = require('./helpers');
  * suppress output.
  * @param {string|Object} options.db MongoDB connection uri or preconnected db
  * object.
+ * @param {string} options.dbName The database name to connect to,
+ * defaults to DB name based on connection URI if not provided
  * @param {Object} options.options MongoDB connection parameters
  * (optional, defaults to `{poolSize: 2, autoReconnect: true, useNewUrlParser: true}`).
  * @param {string=logs} options.collection The name of the collection you want
@@ -60,6 +62,7 @@ let MongoDB = exports.MongoDB = function(options) {
   }
   this.name = options.name || 'mongodb';
   this.db = options.db;
+  this.dbName = (options.dbName || undefined);
   this.options = options.options;
   if (!this.options) {
     this.options = {
@@ -135,7 +138,7 @@ let MongoDB = exports.MongoDB = function(options) {
     return mongodb.MongoClient.connect(logger.db, logger.options
     ).then(client=>{
       logger.mongoClient = client;
-      setupDatabaseAndEmptyQueue(client.db());
+      setupDatabaseAndEmptyQueue(client.db(self.dbName));
     }, err=>{
       console.error('winston-mongodb: error initialising logger', err);
       if (options.tryReconnect) {
@@ -151,11 +154,11 @@ let MongoDB = exports.MongoDB = function(options) {
   } else if ('function' === typeof this.db.then) {
     this.db.then(client=>{
       this.mongoClient = client;
-      setupDatabaseAndEmptyQueue(client.db());
+      setupDatabaseAndEmptyQueue(client.db(self.dbName));
     }, err=>console.error('winston-mongodb: error initialising logger from promise', err));
   } else if ('function' === typeof this.db.db) {
     this.mongoClient = this.db;
-    setupDatabaseAndEmptyQueue(this.db.db())
+    setupDatabaseAndEmptyQueue(this.db.db(self.dbName))
   } else { // preconnected object
     console.warn(
       'winston-mongodb: preconnected object support is deprecated and will be removed in v5');

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "winston-mongodb",
       "version": "5.0.7",
       "license": "MIT",
       "dependencies": {
@@ -277,7 +278,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -1026,8 +1026,7 @@
         "bson": "^1.1.4",
         "denque": "^1.4.1",
         "require_optional": "^1.0.1",
-        "safe-buffer": "^5.1.2",
-        "saslprep": "^1.0.0"
+        "safe-buffer": "^5.1.2"
       },
       "engines": {
         "node": ">=4"

--- a/test/winston-mongodb-test.js
+++ b/test/winston-mongodb-test.js
@@ -14,6 +14,8 @@ const MongoDB = require('../lib/winston-mongodb').MongoDB;
 
 const dbUrl = process.env.USER_WINSTON_MONGODB_URL
     ||process.env.WINSTON_MONGODB_URL||'mongodb://localhost:27017/winston';
+const dbName = process.env.WINSTON_MONGODB_DBNAME
+    ||'otherWinston';
 
 mongoose.connect(dbUrl, {useNewUrlParser: true});
 
@@ -27,9 +29,18 @@ describe('winston-mongodb-manual-tests', function() {
 });
 
 test_suite({name: '{db: url}', Transport: MongoDB, construct: {db: dbUrl}});
+test_suite({name: '{db: url, dbName: string}', Transport: MongoDB,
+    construct: {db: dbUrl, dbName}});
 test_suite({name: '{db: url} on capped collection', Transport: MongoDB,
     construct: {db: dbUrl, capped: true, collection: 'cappedLog'}});
+test_suite({name: '{db: url, dbName: string} on capped collection', Transport: MongoDB,
+    construct: {db: dbUrl, dbName, capped: true, collection: 'cappedLog'}});
 test_suite({name: '{db: client promise}', Transport: MongoDB,
     construct: {db: mongodb.MongoClient.connect(dbUrl, {useNewUrlParser: true})}});
+test_suite({name: '{db: client promise, dbName: string}', Transport: MongoDB,
+  construct: {
+    dbName,
+    db: mongodb.MongoClient.connect(dbUrl, {useNewUrlParser: true})},
+  });
 test_suite({name: '{db: mongoose client}', Transport: MongoDB,
     construct: {db: mongoose.connection}});


### PR DESCRIPTION
Adding support for using a different DB name than the default one from the connection URI.

The use case is to allow users to use log with a pre-connected mongo client, but use a different name than the default.