### PR TITLE
Fixing metadata storing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 .idea
+.env

--- a/lib/winston-mongodb.d.ts
+++ b/lib/winston-mongodb.d.ts
@@ -46,10 +46,10 @@ declare module 'winston-mongodb' {
        /**
         * MongoDB connection uri, pre-connected db object or promise object which will be resolved with pre-connected db object.
         *
-        * @type {(string | object | Promise<object>)}
+        * @type {(string | Promise<object>)}
         * @memberof MongoDBConnectionOptions
         */
-       db: string | object | Promise<any>;
+       db: string | Promise<any>;
        /**
         * MongoDB connection parameters (optional, defaults to {poolSize: 2, autoReconnect: true}).
         *

--- a/lib/winston-mongodb.d.ts
+++ b/lib/winston-mongodb.d.ts
@@ -46,10 +46,10 @@ declare module 'winston-mongodb' {
        /**
         * MongoDB connection uri, pre-connected db object or promise object which will be resolved with pre-connected db object.
         *
-        * @type {(string | Promise<any>)}
+        * @type {(string | object | Promise<object>)}
         * @memberof MongoDBConnectionOptions
         */
-       db: string | Promise<any>;
+       db: string | object | Promise<any>;
        /**
         * MongoDB connection parameters (optional, defaults to {poolSize: 2, autoReconnect: true}).
         *

--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -223,7 +223,7 @@ MongoDB.prototype.log = function(info, cb) {
     // technically label should be in meta, but let's remove it as it is stored in separate field
     const {level, message, label, ...meta} = info;
     // prepare meta object for storage
-    metaData = helpers.prepareMetaData(meta);
+    const metaData = helpers.prepareMetaData(meta);
     // if metadata is not empty object add it to entry - makes no sense to store empty object
     if (Object.keys(metaData).length > 0) {
       entry[this.metaKey] = metaData;

--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -219,7 +219,7 @@ MongoDB.prototype.log = function(info, cb) {
     let entry = { timestamp: new Date(), level: (this.decolorize) ? info.level.replace(decolorizeRegex, '') : info.level };
     let message = util.format(info.message, ...(info.splat || []));
     entry.message = (this.decolorize) ? message.replace(decolorizeRegex, '') : message;
-    entry.meta = helpers.prepareMetaData(info[this.metaKey]);
+    entry[this.metaKey] = helpers.prepareMetaData(info[this.metaKey]);
     if (this.storeHost) {
       entry.hostname = this.hostname;
     }

--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -222,9 +222,11 @@ MongoDB.prototype.log = function(info, cb) {
     // get 'meta' object from info object - as per winston doc: Properties besides level and message are considered as "meta".
     // technically label should be in meta, but let's remove it as it is stored in separate field
     const {level, message, label, ...meta} = info;
+    // prepare meta object for storage
+    metaData = helpers.prepareMetaData(meta);
     // if metadata is not empty object add it to entry - makes no sense to store empty object
-    if (Object.keys(meta).length > 0) {
-      entry[this.metaKey] = helpers.prepareMetaData(meta);
+    if (Object.keys(metaData).length > 0) {
+      entry[this.metaKey] = metaData;
     }
     if (this.storeHost) {
       entry.hostname = this.hostname;

--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -217,9 +217,15 @@ MongoDB.prototype.log = function(info, cb) {
     }
     const decolorizeRegex = new RegExp(/\u001b\[[0-9]{1,2}m/g);
     let entry = { timestamp: new Date(), level: (this.decolorize) ? info.level.replace(decolorizeRegex, '') : info.level };
-    let message = util.format(info.message, ...(info.splat || []));
-    entry.message = (this.decolorize) ? message.replace(decolorizeRegex, '') : message;
-    entry[this.metaKey] = helpers.prepareMetaData(info[this.metaKey]);
+    let msg = util.format(info.message, ...(info.splat || []));
+    entry.message = (this.decolorize) ? msg.replace(decolorizeRegex, '') : msg;
+    // get 'meta' object from info object - as per winston doc: Properties besides level and message are considered as "meta".
+    // technically label should be in meta, but let's remove it as it is stored in separate field
+    const {level, message, label, ...meta} = info;
+    // if metadata is not empty object add it to entry - makes no sense to store empty object
+    if (Object.keys(meta).length > 0) {
+      entry[this.metaKey] = helpers.prepareMetaData(meta);
+    }
     if (this.storeHost) {
       entry.hostname = this.hostname;
     }

--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -220,8 +220,7 @@ MongoDB.prototype.log = function(info, cb) {
     let msg = util.format(info.message, ...(info.splat || []));
     entry.message = (this.decolorize) ? msg.replace(decolorizeRegex, '') : msg;
     // get 'meta' object from info object - as per winston doc: Properties besides level and message are considered as "meta".
-    // technically label should be in meta, but let's remove it as it is stored in separate field
-    const {level, message, label, ...meta} = info;
+    const {level, message, ...meta} = info;
     // prepare meta object for storage
     const metaData = helpers.prepareMetaData(meta);
     // if metadata is not empty object add it to entry - makes no sense to store empty object
@@ -231,9 +230,8 @@ MongoDB.prototype.log = function(info, cb) {
     if (this.storeHost) {
       entry.hostname = this.hostname;
     }
-    if (label) {
-      entry.label = label;
-    } else if (this.label) {
+    
+    if (this.label) {
       entry.label = this.label;
     }
     this.logDb.collection(this.collection).insertOne(entry).then(()=>{

--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -231,7 +231,9 @@ MongoDB.prototype.log = function(info, cb) {
     if (this.storeHost) {
       entry.hostname = this.hostname;
     }
-    if (this.label) {
+    if (label) {
+      entry.label = label;
+    } else if (this.label) {
       entry.label = this.label;
     }
     this.logDb.collection(this.collection).insertOne(entry).then(()=>{

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "winston-mongodb",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "winston-mongodb",
-      "version": "5.1.0",
+      "version": "5.1.1",
       "license": "MIT",
       "dependencies": {
         "mongodb": "^3.6.2",
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "abstract-winston-transport": "~0.5.1",
+        "dotenv": "^16.1.4",
         "mocha": "^10.2.0",
         "mongoose": "^5.10.5",
         "winston": "^3.3.3"
@@ -425,6 +426,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.1.4.tgz",
+      "integrity": "sha512-m55RtE8AsPeJBpOIFKihEmqUcoVncQIwo7x9U8ZwLEZw9ZpXboz2c+rvog+jUaJvVrZ5kBOeYQBX5+8Aa/OZQw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/emoji-regex": {
@@ -1826,6 +1839,12 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true
+    },
+    "dotenv": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.1.4.tgz",
+      "integrity": "sha512-m55RtE8AsPeJBpOIFKihEmqUcoVncQIwo7x9U8ZwLEZw9ZpXboz2c+rvog+jUaJvVrZ5kBOeYQBX5+8Aa/OZQw==",
       "dev": true
     },
     "emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "abstract-winston-transport": "~0.5.1",
+    "dotenv": "^16.1.4",
     "mocha": "^10.2.0",
     "mongoose": "^5.10.5",
     "winston": "^3.3.3"

--- a/test/winston-mongodb-test.js
+++ b/test/winston-mongodb-test.js
@@ -6,6 +6,7 @@
  * @author 0@39.yt (Yurij Mikhalevich)
  */
 'use strict';
+require('dotenv').config();
 const mongodb = require('mongodb');
 const mongoose = require('mongoose');
 const test_suite = require('abstract-winston-transport');


### PR DESCRIPTION
1. added `dotenv` as dev-dependency for easier testing
2. originally I wanted to fix dts too, so it won't be necessary to provide Promise with connected mongo-client, but left it as it is
3. fixed (I hope I understood your intention correctly) metadata storing - winston sends whole info object and metadata is everything besides label and message
4. fixed metadata key - you could provide a new name as an option, but was stored always as `meta`