### PR TITLE
Properly handle objects with null prototype in metadata

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -26,8 +26,8 @@ exports.prepareMetaData = meta=>{
  * @param {Array=} opt_parents Object's parents
  */
 function cloneMeta(node, opt_parents) {
-  if (!(node instanceof Object) || (node instanceof ObjectID)
-      || (node instanceof Buffer)) {
+  if (!((node !== null && typeof node === 'object') || typeof node === 'function')
+      || (node instanceof ObjectID) || (node instanceof Buffer)) {
     return node;
   }
   let copy = Array.isArray(node) ? [] : {};
@@ -48,7 +48,7 @@ function cloneMeta(node, opt_parents) {
     if (newKey.includes('.') || newKey.includes('$')) {
         newKey = newKey.replace(/\./g, '[dot]').replace(/\$/g, '[$]');
     }
-    if (value instanceof Object) {
+    if ((value !== null && typeof value === 'object') || typeof value === 'function') {
       if (opt_parents.indexOf(value) === -1) {
         copy[newKey] = cloneMeta(value, opt_parents);
       } else {

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -15,20 +15,21 @@ class CustomError extends Error {
   }
 }
 
-const originalData = {
-  customDate: new Date(),
-  standardError: new Error('some error'),
-  customError: new CustomError()
-};
-
 describe('winston-mongodb-helpers', function() {
   describe('#prepareMetaData()', function() {
-    let preparedData = helpers.prepareMetaData(originalData);
     it('should preserve Date instances', function() {
+      const originalData = { customDate: new Date() };
+
+      const preparedData = helpers.prepareMetaData(originalData);
+
       assert(preparedData.customDate instanceof Date);
       assert.strictEqual(+preparedData.customDate, +originalData.customDate);
     });
     it('should store Error objects', function() {
+      const originalData = { standardError: new Error('some error') };
+
+      const preparedData = helpers.prepareMetaData(originalData);
+
       assert(preparedData.standardError instanceof Object);
       assert(!(preparedData.standardError instanceof Error));
       assert.strictEqual(preparedData.standardError.message, originalData.standardError.message);
@@ -36,6 +37,10 @@ describe('winston-mongodb-helpers', function() {
       assert.strictEqual(preparedData.standardError.stack, originalData.standardError.stack);
     });
     it('should store extra fields for custom Error objects', function() {
+      const originalData = { customError: new CustomError() };
+      
+      const preparedData = helpers.prepareMetaData(originalData);
+
       assert(preparedData.customError instanceof Object);
       assert(!(preparedData.customError instanceof Error));
       assert.strictEqual(preparedData.customError.message, originalData.customError.message);

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -124,5 +124,23 @@ describe('winston-mongodb-helpers', function() {
 
       assert.deepStrictEqual(preparedData, expected);
     });
+    it('should handle objects with null prototype', function() {
+      const originalData = Object.create(null);
+      originalData['key.with.dots'] = true;
+      originalData['$test$'] = true;      
+      originalData.nestedObjectValue = { nestedKey: originalData };
+      originalData.arrayValue = [originalData, 'test', { nestedKey: originalData }];
+
+      const preparedData = helpers.prepareMetaData(originalData);
+
+      const expected = {
+        'key[dot]with[dot]dots': true,
+        '[$]test[$]': true,
+        nestedObjectValue: { nestedKey: '[Circular]' },
+        arrayValue: ['[Circular]', 'test', { nestedKey: '[Circular]' }]
+      };
+
+      assert.deepStrictEqual(preparedData, expected);
+    });
   });
 });


### PR DESCRIPTION
I was facing an issue where winston-mongodb didn't properly remove dots from object keys in metadata. It turns out that these object keys were inside an object with `null` prototype, which therefore returns `false` for an `instanceof Object` check.

Before performing the actual code change, I added a bunch of tests to safeguard the existing functionality.