### PR TITLE
bump mongodb driver to 5.9.1

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -5,7 +5,7 @@
  * @author 0@39.yt (Yurij Mikhalevich)
  */
 'use strict';
-const ObjectID = require('mongodb').ObjectID;
+const ObjectId = require('mongodb').ObjectId;
 
 
 /**
@@ -28,7 +28,7 @@ exports.prepareMetaData = meta => {
  */
 function cloneMeta(node, optParents) {
   if (!((node !== null && typeof node === 'object') || typeof node === 'function')
-      || (node instanceof ObjectID) || (node instanceof Buffer)) {
+      || (node instanceof ObjectId) || (node instanceof Buffer)) {
     return node;
   }
   let copy = Array.isArray(node) ? [] : {};

--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -66,8 +66,7 @@ const MongoDB = exports.MongoDB = function (options) {
   this.options = options.options;
   if (!this.options) {
     this.options = {
-      poolSize: 2,
-      autoReconnect: true,
+      maxPoolSize: 2,
       useNewUrlParser: true
     };
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.1.1",
       "license": "MIT",
       "dependencies": {
-        "mongodb": "^3.6.2",
+        "mongodb": "^5.9.1",
         "winston-transport": "^4.4.0"
       },
       "devDependencies": {
@@ -18,11 +18,11 @@
         "dotenv": "^16.1.4",
         "mocha": "^10.2.0",
         "mongodb-memory-server": "^8.13.0",
-        "mongoose": "^7.3.4",
+        "mongoose": "^7.6.1",
         "winston": "^3.3.3"
       },
       "engines": {
-        "node": ">=6.8.1"
+        "node": ">=14.20.1"
       },
       "peerDependencies": {
         "winston": "^3.0.0"
@@ -42,7 +42,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
       "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-crypto/util": "^3.0.0",
@@ -54,14 +53,12 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
       "optional": true
     },
     "node_modules/@aws-crypto/ie11-detection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
       "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^1.11.1"
@@ -71,14 +68,12 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
       "optional": true
     },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
       "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-crypto/ie11-detection": "^3.0.0",
@@ -95,14 +90,12 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
       "optional": true
     },
     "node_modules/@aws-crypto/sha256-js": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
       "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-crypto/util": "^3.0.0",
@@ -114,14 +107,12 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
       "optional": true
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
       "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^1.11.1"
@@ -131,14 +122,12 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
       "optional": true
     },
     "node_modules/@aws-crypto/util": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
       "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
@@ -150,14 +139,12 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
       "optional": true
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
       "version": "3.369.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.369.0.tgz",
       "integrity": "sha512-YZSjxtWJ70Xj4G230iDGLXJHF4asy1FrTnTkNfyMA3uHmhgL3kUI9yk9E93FRy9XWboI8a39WC0vEgr6zvuBFQ==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -205,7 +192,6 @@
       "version": "3.369.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.369.0.tgz",
       "integrity": "sha512-SjJd9QGT9ccHOY64qnMfvVjrneBORIx/k8OdtL0nV2wemPqCM9uAm+TYZ01E91D/+lfXS+lLMGSidSA39PMIOA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -250,7 +236,6 @@
       "version": "3.369.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.369.0.tgz",
       "integrity": "sha512-NOnsRrkHMss9pE68uTPMEt1KoW6eWt4ZCesJayCOiIgmIA/AhXHz06IBCYJ9eu9Xbu/55FDr4X3VCtUf7Rfh6g==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -295,7 +280,6 @@
       "version": "3.369.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.369.0.tgz",
       "integrity": "sha512-kyZl654U27gsQX9UjiiO4CX5M6kHwzDouwbhjc5HshQld/lUbJQ4uPpAwhlbZiqnzGeB639MdAGaSwrOOw2ixw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -344,7 +328,6 @@
       "version": "3.369.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.369.0.tgz",
       "integrity": "sha512-E69Ya4JnLO2ymtDZSGwbpXXMS4Pr3b3g+rZ3BduPc2fxRSLDfCxKE1GuO56u9pCbjZL6lJ+5FB8i7v0ptsVrOQ==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-sdk/client-cognito-identity": "3.369.0",
@@ -361,7 +344,6 @@
       "version": "3.369.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.369.0.tgz",
       "integrity": "sha512-EZUXGLjnun5t5/dVYJ9yyOwPAJktOdLEQSwtw7Q9XOxaNqVFFz9EU+TwYraV4WZ3CFRNn7GEIctVlXAHVFLm/w==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-sdk/types": "3.369.0",
@@ -377,7 +359,6 @@
       "version": "3.369.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.369.0.tgz",
       "integrity": "sha512-12XXd4gnrn05adio/xPF8Nxl99L2FFzksbFILDIfSni7nLDX0m2XprnkswQiCKSbfDIQQsgnnh2F+HhorLuqfQ==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.369.0",
@@ -399,7 +380,6 @@
       "version": "3.369.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.369.0.tgz",
       "integrity": "sha512-vxX4s33EpRDh7OhKBDVAPxdBxVHPOOj1r7nN6f0hZLw5WPeeffSjLqw+MnFj33gSO7Htnt+Q0cAJQzeY5G8q3A==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.369.0",
@@ -422,7 +402,6 @@
       "version": "3.369.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.369.0.tgz",
       "integrity": "sha512-OyasKV3mZz6TRSxczRnyZoifrtYwqGBxtr75YP37cm/JkecDshHXRcE8Jt9LyBg/93oWfKou03WVQiY9UIDJGQ==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-sdk/types": "3.369.0",
@@ -439,7 +418,6 @@
       "version": "3.369.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.369.0.tgz",
       "integrity": "sha512-qXbEsmgFpGPbRVnwBYPxL53wQuue0+Z8tVu877itbrzpHm61AuQ04Hn8T1boKrr40excDuxiSrCX5oCKRG4srQ==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-sdk/client-sso": "3.369.0",
@@ -458,7 +436,6 @@
       "version": "3.369.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.369.0.tgz",
       "integrity": "sha512-oFGxC839pQTJ6djFEBuokSi3/jNjNMVgZSpg26Z23V/r3vKRSgXfVmeus1FLYIWg0jO7KFsMPo9eVJW6auzw6w==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-sdk/types": "3.369.0",
@@ -474,7 +451,6 @@
       "version": "3.369.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.369.0.tgz",
       "integrity": "sha512-c3H3iEiutebVvHQY7igvlAKup/P8dRdpf3QqJNOCga/w6tR+MMdjhJBanHDeJjmyREfBTPySkaNY2gsLODtmCg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-sdk/client-cognito-identity": "3.369.0",
@@ -501,7 +477,6 @@
       "version": "3.369.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.369.0.tgz",
       "integrity": "sha512-ysbur68WHY7RYpGfth1Iu0+S03nSCLtIHJ+CDVYcVcyvYxaAv6y3gvfrkH9oL220uX75UVLj3tCKgAaLUBy5uA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-sdk/types": "3.369.0",
@@ -517,7 +492,6 @@
       "version": "3.369.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.369.0.tgz",
       "integrity": "sha512-mp4gVRaFRRX+LEDEIlPxHOI/+k1jPPp0tuKyoyNZQS8IPOL+6bqFdPan03hkTjujeyaZOyRjpaXXat6k1HkHhw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-sdk/types": "3.369.0",
@@ -532,7 +506,6 @@
       "version": "3.369.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.369.0.tgz",
       "integrity": "sha512-V7TNhHRTwiKlVXiaW2CYGcm3vObWdG5zU0SN7ZxHDT27eTRYL8ncVpDnQZ65HfekXL8T9llVibBTYYvZrxLJ1g==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-sdk/types": "3.369.0",
@@ -548,7 +521,6 @@
       "version": "3.369.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.369.0.tgz",
       "integrity": "sha512-Igizyt7TWy8kTitvE6o7R1Cfa4qLqijS/WxqT1cnHscQyZFFiIJVNypWeV4V19DZ9Msb/feAQdc8EWgHvZvYGA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-sdk/middleware-signing": "3.369.0",
@@ -564,7 +536,6 @@
       "version": "3.369.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.369.0.tgz",
       "integrity": "sha512-55qihn+9/zjsHUNvEgc4OUWQBxVlKW9C+whVhdy8H8olwAnfOH1ui9xXQ+SAyBCD9ck3vAY89VmBeQQQGZVVQw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-sdk/types": "3.369.0",
@@ -583,7 +554,6 @@
       "version": "3.369.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.369.0.tgz",
       "integrity": "sha512-a7Wb3s0y+blGF654GZv3nI3ZMRARAGH7iQrF2gWGtb2Qq0f3TQGHmpoHddWObYxiFWYzdXdTC3kbsAW1zRwEAA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-sdk/types": "3.369.0",
@@ -600,7 +570,6 @@
       "version": "3.369.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.369.0.tgz",
       "integrity": "sha512-xIz8KbF4RMlMq0aAJbVocLB03OiqJIU5RLy+2t+bKMQ60fV4bnVINH5GxAMiFXiBIQVqfehFJlxJACtEphqQwA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-sdk/client-sso-oidc": "3.369.0",
@@ -618,7 +587,6 @@
       "version": "3.369.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.369.0.tgz",
       "integrity": "sha512-0LgII+RatF2OEFaFQcNyX72py4ZgWz+/JAv++PXv0gkIaTRnsJbSveQArNynEK+aAc/rZKWJgBvwT4FvLM2vgA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/types": "1.1.0",
@@ -632,7 +600,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.0.tgz",
       "integrity": "sha512-KzmvisMmuwD2jZXuC9e65JrgsZM97y5NpDU7g347oB+Q+xQLU6hQZ5zFNNbEfwwOJHoOvEVTna+dk1h/lW7alw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -645,7 +612,6 @@
       "version": "3.369.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.369.0.tgz",
       "integrity": "sha512-dkzhhMIvQRsgdomHi8fmgQ3df2cS1jeWAUIPjxV4lBikcvcF2U0CtvH9QYyMpluSNP1IYcEuONe8wfZGSrNjdg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-sdk/types": "3.369.0",
@@ -659,7 +625,6 @@
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
       "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -672,7 +637,6 @@
       "version": "3.369.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.369.0.tgz",
       "integrity": "sha512-wrF0CqnfFac4sYr8jLZXz7B5NPxdW4GettH07Sl3ihO2aXsTvZ0RoyqzwF7Eve8ihbK0vCKt1S3/vZTOLw8sCg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-sdk/types": "3.369.0",
@@ -685,7 +649,6 @@
       "version": "3.369.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.369.0.tgz",
       "integrity": "sha512-RkiGyWp+YUlK4njsvqD7S08aihEW8aMNrT5OXmLGdukEUGWMAyvIcq4XS8MxA02GRPUxTUNInLltXwc1AaDpCw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-sdk/types": "3.369.0",
@@ -709,7 +672,6 @@
       "version": "3.259.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
       "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.3.1"
@@ -904,6 +866,15 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
+      "integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
+      "optional": true,
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -946,7 +917,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.0.2.tgz",
       "integrity": "sha512-tb2h0b+JvMee+eAxTmhnyqyNk51UXIK949HnE14lFeezKsVJTB30maan+CO2IMwnig2wVYQH84B5qk6ylmKCuA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/types": "^1.1.1",
@@ -960,7 +930,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-1.0.2.tgz",
       "integrity": "sha512-8Bk7CgnVKg1dn5TgnjwPz2ebhxeR7CjGs5yhVYH3S8x0q8yPZZVWwpRIglwXaf5AZBzJlNO1lh+lUhMf2e73zQ==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/types": "^1.1.1",
@@ -976,7 +945,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-1.0.2.tgz",
       "integrity": "sha512-fLjCya+JOu2gPJpCiwSUyoLvT8JdNJmOaTOkKYBZoGf7CzqR6lluSyI+eboZnl/V0xqcfcqBG4tgqCISmWS3/w==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/node-config-provider": "^1.0.2",
@@ -993,7 +961,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-1.0.2.tgz",
       "integrity": "sha512-eW/XPiLauR1VAgHKxhVvgvHzLROUgTtqat2lgljztbH8uIYWugv7Nz+SgCavB+hWRazv2iYgqrSy74GvxXq/rg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
@@ -1006,7 +973,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-1.0.2.tgz",
       "integrity": "sha512-kynyofLf62LvR8yYphPPdyHb8fWG3LepFinM/vWUTG2Q1pVpmPCM530ppagp3+q2p+7Ox0UvSqldbKqV/d1BpA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/protocol-http": "^1.1.1",
@@ -1020,7 +986,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-1.0.2.tgz",
       "integrity": "sha512-K6PKhcUNrJXtcesyzhIvNlU7drfIU7u+EMQuGmPw6RQDAg/ufUcfKHz4EcUhFAodUmN+rrejhRG9U6wxjeBOQA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/types": "^1.1.1",
@@ -1036,7 +1001,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-1.0.2.tgz",
       "integrity": "sha512-B1Y3Tsa6dfC+Vvb+BJMhTHOfFieeYzY9jWQSTR1vMwKkxsymD0OIAnEw8rD/RiDj/4E4RPGFdx9Mdgnyd6Bv5Q==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/types": "^1.1.1",
@@ -1047,7 +1011,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.0.2.tgz",
       "integrity": "sha512-pkyBnsBRpe+c/6ASavqIMRBdRtZNJEVJOEzhpxZ9JoAXiZYbkfaSMRA/O1dUxGdJ653GHONunnZ4xMo/LJ7utQ==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -1060,7 +1023,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-1.0.2.tgz",
       "integrity": "sha512-pa1/SgGIrSmnEr2c9Apw7CdU4l/HW0fK3+LKFCPDYJrzM0JdYpqjQzgxi31P00eAkL0EFBccpus/p1n2GF9urw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/protocol-http": "^1.1.1",
@@ -1075,7 +1037,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-1.0.3.tgz",
       "integrity": "sha512-GsWvTXMFjSgl617PCE2km//kIjjtvMRrR2GAuRDIS9sHiLwmkS46VWaVYy+XE7ubEsEtzZ5yK2e8TKDR6Qr5Lw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/middleware-serde": "^1.0.2",
@@ -1092,7 +1053,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-1.0.4.tgz",
       "integrity": "sha512-G7uRXGFL8c3F7APnoIMTtNAHH8vT4F2qVnAWGAZaervjupaUQuRRHYBLYubK0dWzOZz86BtAXKieJ5p+Ni2Xpg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/protocol-http": "^1.1.1",
@@ -1111,7 +1071,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
       "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -1121,7 +1080,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-1.0.2.tgz",
       "integrity": "sha512-T4PcdMZF4xme6koUNfjmSZ1MLi7eoFeYCtodQNQpBNsS77TuJt1A6kt5kP/qxrTvfZHyFlj0AubACoaUqgzPeg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/types": "^1.1.1",
@@ -1135,7 +1093,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-1.0.2.tgz",
       "integrity": "sha512-H7/uAQEcmO+eDqweEFMJ5YrIpsBwmrXSP6HIIbtxKJSQpAcMGY7KrR2FZgZBi1FMnSUOh+rQrbOyj5HQmSeUBA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -1148,7 +1105,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-1.0.2.tgz",
       "integrity": "sha512-HU7afWpTToU0wL6KseGDR2zojeyjECQfr8LpjAIeHCYIW7r360ABFf4EaplaJRMVoC3hD9FeltgI3/NtShOqCg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/property-provider": "^1.0.2",
@@ -1164,7 +1120,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.0.3.tgz",
       "integrity": "sha512-PcPUSzTbIb60VCJCiH0PU0E6bwIekttsIEf5Aoo/M0oTfiqsxHTn0Rcij6QoH6qJy6piGKXzLSegspXg5+Kq6g==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/abort-controller": "^1.0.2",
@@ -1181,7 +1136,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-1.0.2.tgz",
       "integrity": "sha512-pXDPyzKX8opzt38B205kDgaxda6LHcTfPvTYQZnwP6BAPp1o9puiCPjeUtkKck7Z6IbpXCPUmUQnzkUzWTA42Q==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/types": "^1.1.1",
@@ -1195,7 +1149,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.1.tgz",
       "integrity": "sha512-mFLFa2sSvlUxm55U7B4YCIsJJIMkA6lHxwwqOaBkral1qxFz97rGffP/mmd4JDuin1EnygiO5eNJGgudiUgmDQ==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/types": "^1.1.1",
@@ -1209,7 +1162,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.0.2.tgz",
       "integrity": "sha512-6P/xANWrtJhMzTPUR87AbXwSBuz1SDHIfL44TFd/GT3hj6rA+IEv7rftEpPjayUiWRocaNnrCPLvmP31mobOyA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/types": "^1.1.1",
@@ -1224,7 +1176,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-1.0.2.tgz",
       "integrity": "sha512-IWxwxjn+KHWRRRB+K2Ngl+plTwo2WSgc2w+DvLy0DQZJh9UGOpw40d6q97/63GBlXIt4TEt5NbcFrO30CKlrsA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/types": "^1.1.1",
@@ -1238,7 +1189,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-1.0.3.tgz",
       "integrity": "sha512-2eglIYqrtcUnuI71yweu7rSfCgt6kVvRVf0C72VUqrd0LrV1M0BM0eYN+nitp2CHPSdmMI96pi+dU9U/UqAMSA==",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=14.0.0"
@@ -1248,7 +1198,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-1.0.2.tgz",
       "integrity": "sha512-bdQj95VN+lCXki+P3EsDyrkpeLn8xDYiOISBGnUG/AGPYJXN8dmp4EhRRR7XOoLoSs8anZHR4UcGEOzFv2jwGw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/types": "^1.1.1",
@@ -1262,7 +1211,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-1.0.2.tgz",
       "integrity": "sha512-rpKUhmCuPmpV5dloUkOb9w1oBnJatvKQEjIHGmkjRGZnC3437MTdzWej9TxkagcZ8NRRJavYnEUixzxM1amFig==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/eventstream-codec": "^1.0.2",
@@ -1282,7 +1230,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-1.0.4.tgz",
       "integrity": "sha512-gpo0Xl5Nyp9sgymEfpt7oa9P2q/GlM3VmQIdm+FeH0QEdYOQx3OtvwVmBYAMv2FIPWxkMZlsPYRTnEiBTK5TYg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/middleware-stack": "^1.0.2",
@@ -1298,7 +1245,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.1.tgz",
       "integrity": "sha512-tMpkreknl2gRrniHeBtdgQwaOlo39df8RxSrwsHVNIGXULy5XP6KqgScUw2m12D15wnJCKWxVhCX+wbrBW/y7g==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -1311,7 +1257,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-1.0.2.tgz",
       "integrity": "sha512-0JRsDMQe53F6EHRWksdcavKDRjyqp8vrjakg8EcCUOa7PaFRRB1SO/xGZdzSlW1RSTWQDEksFMTCEcVEKmAoqA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/querystring-parser": "^1.0.2",
@@ -1323,7 +1268,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-1.0.2.tgz",
       "integrity": "sha512-BCm15WILJ3SL93nusoxvJGMVfAMWHZhdeDZPtpAaskozuexd0eF6szdz4kbXaKp38bFCSenA6bkUHqaE3KK0dA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^1.0.2",
@@ -1337,7 +1281,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-1.0.2.tgz",
       "integrity": "sha512-Xh8L06H2anF5BHjSYTg8hx+Itcbf4SQZnVMl4PIkCOsKtneMJoGjPRLy17lEzfoh/GOaa0QxgCP6lRMQWzNl4w==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -1347,7 +1290,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-1.0.2.tgz",
       "integrity": "sha512-nXHbZsUtvZeyfL4Ceds9nmy2Uh2AhWXohG4vWHyjSdmT8cXZlJdmJgnH6SJKDjyUecbu+BpKeVvSrA4cWPSOPA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -1360,7 +1302,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.0.2.tgz",
       "integrity": "sha512-lHAYIyrBO9RANrPvccnPjU03MJnWZ66wWuC5GjWWQVfsmPwU6m00aakZkzHdUT6tGCkGacXSgArP5wgTgA+oCw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^1.0.2",
@@ -1374,7 +1315,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-1.0.2.tgz",
       "integrity": "sha512-HOdmDm+3HUbuYPBABLLHtn8ittuRyy+BSjKOA169H+EMc+IozipvXDydf+gKBRAxUa4dtKQkLraypwppzi+PRw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -1387,7 +1327,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-1.0.2.tgz",
       "integrity": "sha512-J1u2PO235zxY7dg0+ZqaG96tFg4ehJZ7isGK1pCBEA072qxNPwIpDzUVGnLJkHZvjWEGA8rxIauDtXfB0qxeAg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/property-provider": "^1.0.2",
@@ -1403,7 +1342,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-1.0.2.tgz",
       "integrity": "sha512-9/BN63rlIsFStvI+AvljMh873Xw6bbI6b19b+PVYXyycQ2DDQImWcjnzRlHW7eP65CCUNGQ6otDLNdBQCgMXqg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/config-resolver": "^1.0.2",
@@ -1421,7 +1359,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-1.0.2.tgz",
       "integrity": "sha512-Bxydb5rMJorMV6AuDDMOxro3BMDdIwtbQKHpwvQFASkmr52BnpDsWlxgpJi8Iq7nk1Bt4E40oE1Isy/7ubHGzg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -1434,7 +1371,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-1.0.2.tgz",
       "integrity": "sha512-vtXK7GOR2BoseCX8NCGe9SaiZrm9M2lm/RVexFGyPuafTtry9Vyv7hq/vw8ifd/G/pSJ+msByfJVb1642oQHKw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -1447,7 +1383,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-1.0.4.tgz",
       "integrity": "sha512-RnZPVFvRoqdj2EbroDo3OsnnQU8eQ4AlnZTOGusbYKybH3269CFdrZfZJloe60AQjX7di3J6t/79PjwCLO5Khw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/service-error-classification": "^1.0.3",
@@ -1461,7 +1396,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-1.0.2.tgz",
       "integrity": "sha512-qyN2M9QFMTz4UCHi6GnBfLOGYKxQZD01Ga6nzaXFFC51HP/QmArU72e4kY50Z/EtW8binPxspP2TAsGbwy9l3A==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/fetch-http-handler": "^1.0.2",
@@ -1481,7 +1415,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.0.2.tgz",
       "integrity": "sha512-k8C0BFNS9HpBMHSgUDnWb1JlCQcFG+PPlVBq9keP4Nfwv6a9Q0yAfASWqUCtzjuMj1hXeLhn/5ADP6JxnID1Pg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -1494,7 +1427,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-1.0.2.tgz",
       "integrity": "sha512-V4cyjKfJlARui0dMBfWJMQAmJzoW77i4N3EjkH/bwnE2Ngbl4tqD2Y0C/xzpzY/J1BdxeCKxAebVFk8aFCaSCw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^1.0.2",
@@ -1507,8 +1439,7 @@
     "node_modules/@types/node": {
       "version": "18.7.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
-      "integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
-      "dev": true
+      "integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg=="
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.2",
@@ -1518,14 +1449,12 @@
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog==",
-      "dev": true
+      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
     },
     "node_modules/@types/whatwg-url": {
       "version": "8.2.2",
       "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
       "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "@types/webidl-conversions": "*"
@@ -1712,20 +1641,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/bl": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
-      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
-      "dependencies": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      }
-    },
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "dev": true,
       "optional": true
     },
     "node_modules/brace-expansion": {
@@ -1756,11 +1675,11 @@
       "dev": true
     },
     "node_modules/bson": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
-      "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
+      "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
       "engines": {
-        "node": ">=0.6.19"
+        "node": ">=14.20.1"
       }
     },
     "node_modules/buffer": {
@@ -1956,11 +1875,6 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -2011,14 +1925,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "peer": true
-    },
-    "node_modules/denque": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
-      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==",
-      "engines": {
-        "node": ">=0.10"
-      }
     },
     "node_modules/diagnostics": {
       "version": "1.1.1",
@@ -2501,7 +2407,6 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
       "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-      "dev": true,
       "funding": [
         {
           "type": "paypal",
@@ -2888,8 +2793,7 @@
     "node_modules/ip": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
-      "dev": true
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
     },
     "node_modules/is-arrayish": {
       "version": "0.3.2",
@@ -2987,11 +2891,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3233,36 +3132,38 @@
       "dev": true
     },
     "node_modules/mongodb": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
-      "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.1.tgz",
+      "integrity": "sha512-NBGA8AfJxGPeB12F73xXwozt8ZpeIPmCUeWRwl9xejozTXFes/3zaep9zhzs1B/nKKsw4P3I4iPfXl3K7s6g+Q==",
       "dependencies": {
-        "bl": "^2.2.1",
-        "bson": "^1.1.4",
-        "denque": "^1.4.1",
-        "optional-require": "^1.1.8",
-        "safe-buffer": "^5.1.2"
+        "bson": "^5.5.0",
+        "mongodb-connection-string-url": "^2.6.0",
+        "socks": "^2.7.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=14.20.1"
       },
       "optionalDependencies": {
-        "saslprep": "^1.0.0"
+        "@mongodb-js/saslprep": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.0.0",
+        "kerberos": "^1.0.0 || ^2.0.0",
+        "mongodb-client-encryption": ">=2.3.0 <3",
+        "snappy": "^7.2.2"
       },
       "peerDependenciesMeta": {
-        "aws4": {
+        "@aws-sdk/credential-providers": {
           "optional": true
         },
-        "bson-ext": {
+        "@mongodb-js/zstd": {
           "optional": true
         },
         "kerberos": {
           "optional": true
         },
         "mongodb-client-encryption": {
-          "optional": true
-        },
-        "mongodb-extjson": {
           "optional": true
         },
         "snappy": {
@@ -3274,7 +3175,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
       "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
-      "dev": true,
       "dependencies": {
         "@types/whatwg-url": "^8.2.1",
         "whatwg-url": "^11.0.0"
@@ -3350,26 +3250,15 @@
         "saslprep": "^1.0.3"
       }
     },
-    "node_modules/mongodb/node_modules/optional-require": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
-      "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
-      "dependencies": {
-        "require-at": "^1.0.6"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/mongoose": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.4.3.tgz",
-      "integrity": "sha512-eok0lW6mZJHK2vVSWyJb9tUfPMUuRF3h7YC4pU2K2/YSZBlNDUwvKsHgftMOANbokP2Ry+4ylvzAdW4KjkRFjw==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.6.3.tgz",
+      "integrity": "sha512-moYP2qWCOdWRDeBxqB/zYwQmQnTBsF5DoolX5uPyI218BkiA1ujGY27P0NTd4oWIX+LLkZPw0LDzlc/7oh1plg==",
       "dev": true,
       "dependencies": {
-        "bson": "^5.4.0",
+        "bson": "^5.5.0",
         "kareem": "2.5.1",
-        "mongodb": "5.7.0",
+        "mongodb": "5.9.0",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",
@@ -3383,22 +3272,13 @@
         "url": "https://opencollective.com/mongoose"
       }
     },
-    "node_modules/mongoose/node_modules/bson": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.4.0.tgz",
-      "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.20.1"
-      }
-    },
     "node_modules/mongoose/node_modules/mongodb": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.7.0.tgz",
-      "integrity": "sha512-zm82Bq33QbqtxDf58fLWBwTjARK3NSvKYjyz997KSy6hpat0prjeX/kxjbPVyZY60XYPDNETaHkHJI2UCzSLuw==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.0.tgz",
+      "integrity": "sha512-g+GCMHN1CoRUA+wb1Agv0TI4YTSiWr42B5ulkiAfLLHitGK1R+PkSAf3Lr5rPZwi/3F04LiaZEW0Kxro9Fi2TA==",
       "dev": true,
       "dependencies": {
-        "bson": "^5.4.0",
+        "bson": "^5.5.0",
         "mongodb-connection-string-url": "^2.6.0",
         "socks": "^2.7.1"
       },
@@ -3406,12 +3286,12 @@
         "node": ">=14.20.1"
       },
       "optionalDependencies": {
-        "saslprep": "^1.0.3"
+        "@mongodb-js/saslprep": "^1.1.0"
       },
       "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.201.0",
-        "@mongodb-js/zstd": "^1.1.0",
-        "kerberos": "^2.0.1",
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.0.0",
+        "kerberos": "^1.0.0 || ^2.0.0",
         "mongodb-client-encryption": ">=2.3.0 <3",
         "snappy": "^7.2.2"
       },
@@ -3722,16 +3602,10 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
     "node_modules/punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -3772,25 +3646,6 @@
         "safe-buffer": "^5.1.0"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -3801,14 +3656,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/require-at": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
-      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/require-directory": {
@@ -3884,7 +3731,8 @@
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.4.3",
@@ -3898,6 +3746,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
       "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
@@ -3972,7 +3821,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -3982,7 +3830,6 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
       "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
-      "dev": true,
       "dependencies": {
         "ip": "^2.0.0",
         "smart-buffer": "^4.2.0"
@@ -4065,7 +3912,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-      "dev": true,
       "optional": true
     },
     "node_modules/supports-color": {
@@ -4153,7 +3999,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
       "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.1"
       },
@@ -4170,7 +4015,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4263,7 +4108,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -4272,7 +4116,6 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
       "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-      "dev": true,
       "dependencies": {
         "tr46": "^3.0.0",
         "webidl-conversions": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "logger"
   ],
   "dependencies": {
-    "mongodb": "^3.6.2",
+    "mongodb": "^5.9.1",
     "winston-transport": "^4.4.0"
   },
   "peerDependencies": {
@@ -45,11 +45,11 @@
     "dotenv": "^16.1.4",
     "mocha": "^10.2.0",
     "mongodb-memory-server": "^8.13.0",
-    "mongoose": "^7.3.4",
+    "mongoose": "^7.6.1",
     "winston": "^3.3.3"
   },
   "engines": {
-    "node": ">=6.8.1"
+    "node": ">=14.20.1"
   },
   "main": "./lib/winston-mongodb",
   "scripts": {

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 const assert = require('assert');
-const ObjectID = require('mongodb').ObjectID;
+const ObjectId = require('mongodb').ObjectId;
 const helpers = require('../lib/helpers');
 
 class CustomError extends Error {
@@ -50,7 +50,7 @@ describe('winston-mongodb-helpers', function () {
       assert.strictEqual(preparedData.customError.testField, originalData.customError.testField);
     });
     it('should preserve ObjectIds', function () {
-      const originalData = { objectId: new ObjectID() };
+      const originalData = { objectId: new ObjectId() };
 
       const preparedData = helpers.prepareMetaData(originalData);
 


### PR DESCRIPTION
Hi,

Dependency Changes:

* minimum Node.js 6.8.1 => 14.20.1 (it's required for mongodb 5.9 driver)
* mongedb 3.6.2 => 5.9.1
* mongoose 7.3.4 => 7.6.1 (it uses mongodb 5.9 driver)

Code Changes:
* poolsize deprecated. Changed poolsize to maxPoolSize ([ref](https://mongodb.github.io/node-mongodb-native/2.2/api/MongoClient.html#.connect)).
* autoreconnect deprecated. Default is true.
* ObjectID replaced with ObjectId

Any help or guidance are appreciated.








 



