### PR TITLE
Issue#232 - timestamp format fix

### DIFF
--- a/lib/winston-mongodb.js
+++ b/lib/winston-mongodb.js
@@ -219,7 +219,11 @@ MongoDB.prototype.log = function (info, cb) {
     }
     // eslint-disable-next-line no-control-regex
     const decolorizeRegex = new RegExp(/\u001b\[[0-9]{1,2}m/g);
-    const entry = { timestamp: new Date(), level: (this.decolorize) ? info.level.replace(decolorizeRegex, '') : info.level };
+    const entry = { 
+      // when format option is used in winston, logform will generate timestamp with specified format.
+      timestamp: info.timestamp? info.timestamp : new Date(),
+      level: (this.decolorize) ? info.level.replace(decolorizeRegex, '') : info.level 
+    };
     const msg = util.format(info.message, ...(info.splat || []));
     entry.message = (this.decolorize) ? msg.replace(decolorizeRegex, '') : msg;
     // get 'meta' object from info object - as per winston doc: Properties besides level and message are considered as "meta".


### PR DESCRIPTION
Found logform module is handling the formatting of timestamp, so added conditional operator to either choose info.timestamp or new Date().

Tested the option using sample code provided in the issue.

Before fix:
![image](https://github.com/winstonjs/winston-mongodb/assets/15905780/5b9a2d81-9577-4ed8-8740-d6888f7ff25c)

After fix:
![image](https://github.com/winstonjs/winston-mongodb/assets/15905780/a00ee934-6d8b-4f80-98fa-c00ab449e6fc)
